### PR TITLE
Bump airflow version to 2.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.0.2-python3.8
+FROM apache/airflow:2.8.3
 
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/dags/airflow_log_cleanup.py
+++ b/dags/airflow_log_cleanup.py
@@ -17,7 +17,7 @@ from airflow.models import DAG, Variable
 
 # airflow-log-cleanup
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DAG_ID = os.path.basename(__file__).replace('.pyc', '').replace('.py', '')
 START_DATE = airflow.utils.dates.days_ago(1)
@@ -94,7 +94,7 @@ if hasattr(dag, 'doc_md'):
 if hasattr(dag, 'catchup'):
     dag.catchup = False
 
-start = DummyOperator(
+start = EmptyOperator(
     task_id='start',
     dag=dag)
 

--- a/dags/crossdag/finances_a.py
+++ b/dags/crossdag/finances_a.py
@@ -16,7 +16,7 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.dates import days_ago
 
@@ -37,10 +37,10 @@ with DAG(dag_id=DAG_NAME,
          dagrun_timeout=timedelta(minutes=10),
          schedule_interval=None) as dag:
 
-    income_bookkeep = DummyOperator(task_id='income_bookkeep',
+    income_bookkeep = EmptyOperator(task_id='income_bookkeep',
                                     dag=dag)
 
-    validate_income = DummyOperator(task_id='validate_income',
+    validate_income = EmptyOperator(task_id='validate_income',
                                     dag=dag)
 
     wait_operations_a_calculate_expenses = ExternalTaskSensor(
@@ -50,11 +50,11 @@ with DAG(dag_id=DAG_NAME,
         external_task_id='calculate_expenses',
         check_existence=True)
 
-    outcome_bookkeep = DummyOperator(task_id='outcome_bookkeep',
+    outcome_bookkeep = EmptyOperator(task_id='outcome_bookkeep',
                                      dag=dag)
 
 
-    finances_a_report = DummyOperator(task_id='finances_a_report',
+    finances_a_report = EmptyOperator(task_id='finances_a_report',
                                       dag=dag)
 
     income_bookkeep >> validate_income >> wait_operations_a_calculate_expenses

--- a/dags/crossdag/operations_a.py
+++ b/dags/crossdag/operations_a.py
@@ -16,7 +16,7 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.dates import days_ago
@@ -37,15 +37,15 @@ with DAG(dag_id=DAG_NAME,
          default_args=DEFAULT_ARGS,
          dagrun_timeout=timedelta(minutes=10),
          schedule_interval=None) as dag:
-    calculate_revenue = DummyOperator(task_id='calculate_revenue',
+    calculate_revenue = EmptyOperator(task_id='calculate_revenue',
                                       dag=dag)
 
     trigger_finances_a = TriggerDagRunOperator(task_id='trigger_finances_a',
                                                dag=dag,
                                                trigger_dag_id='finances_a',
-                                               execution_date='{{ execution_date }}')
+                                               execution_date='{{ dag_run.logical_date }}')
 
-    calculate_expenses = DummyOperator(task_id='calculate_expenses',
+    calculate_expenses = EmptyOperator(task_id='calculate_expenses',
                                        dag=dag)
 
     wait_finances_a_expenses_bookkept = ExternalTaskSensor(
@@ -55,7 +55,7 @@ with DAG(dag_id=DAG_NAME,
         external_task_id='outcome_bookkeep',
         check_existence=True)
 
-    operations_a_report = DummyOperator(task_id='operations_a_report',
+    operations_a_report = EmptyOperator(task_id='operations_a_report',
                                         dag=dag)
 
     calculate_revenue >> trigger_finances_a >> calculate_expenses

--- a/dags/crossdag/problem_a.py
+++ b/dags/crossdag/problem_a.py
@@ -18,7 +18,7 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 
 DAG_NAME = 'problem_a'
@@ -38,25 +38,25 @@ with DAG(dag_id=DAG_NAME,
          dagrun_timeout=timedelta(minutes=10),
          schedule_interval=None) as dag:
 
-    calculate_revenue = DummyOperator(task_id='operations_calculate_revenue',
+    calculate_revenue = EmptyOperator(task_id='operations_calculate_revenue',
                                       dag=dag)
 
-    income_bookkeep = DummyOperator(task_id='finances_income_bookkeep',
+    income_bookkeep = EmptyOperator(task_id='finances_income_bookkeep',
                                     dag=dag)
 
-    validate_income = DummyOperator(task_id='finances_validate_income',
+    validate_income = EmptyOperator(task_id='finances_validate_income',
                                     dag=dag)
 
-    calculate_expenses = DummyOperator(task_id='operations_calculate_expenses',
+    calculate_expenses = EmptyOperator(task_id='operations_calculate_expenses',
                                        dag=dag)
 
-    outcome_bookkeep = DummyOperator(task_id='finances_outcome_bookkeep',
+    outcome_bookkeep = EmptyOperator(task_id='finances_outcome_bookkeep',
                                      dag=dag)
 
-    operations_a_report = DummyOperator(task_id='operations_a_report',
+    operations_a_report = EmptyOperator(task_id='operations_a_report',
                                         dag=dag)
 
-    finance_a_report = DummyOperator(task_id='finance_a_report',
+    finance_a_report = EmptyOperator(task_id='finance_a_report',
                                      dag=dag)
 
     calculate_revenue >> income_bookkeep >> validate_income

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,39 +23,60 @@
 # This configuration supports basic configuration using environment variables or an .env file
 # The following variables are supported:
 #
-# AIRFLOW_IMAGE_NAME         - Docker image name used to run Airflow.
-#                              Default: apache/airflow:master-python3.8
-# AIRFLOW_UID                - User ID in Airflow containers
-#                              Default: 50000
-# AIRFLOW_GID                - Group ID in Airflow containers
-#                              Default: 50000
-# _AIRFLOW_WWW_USER_USERNAME - Username for the administrator account.
-#                              Default: airflow
-# _AIRFLOW_WWW_USER_PASSWORD - Password for the administrator account.
-#                              Default: airflow
+# AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
+#                                Default: apache/airflow:2.8.3
+# AIRFLOW_UID                  - User ID in Airflow containers
+#                                Default: 50000
+# AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
+#                                Default: .
+# Those configurations are useful mostly in case of standalone testing/running Airflow in test/try-out mode
+#
+# _AIRFLOW_WWW_USER_USERNAME   - Username for the administrator account (if requested).
+#                                Default: airflow
+# _AIRFLOW_WWW_USER_PASSWORD   - Password for the administrator account (if requested).
+#                                Default: airflow
+# _PIP_ADDITIONAL_REQUIREMENTS - Additional PIP requirements to add when starting all containers.
+#                                Use this option ONLY for quick checks. Installing requirements at container
+#                                startup is done EVERY TIME the service is started.
+#                                A better way is to build a custom image or extend the official image
+#                                as described in https://airflow.apache.org/docs/docker-stack/build.html.
+#                                Default: ''
 #
 # Feel free to modify this file to suit your needs.
 ---
-version: '3'
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.0.2}
+  # In order to add custom dependencies or upgrade provider packages you can use your extended image.
+  # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
+  # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.8.3}
+  # build: .
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-    AIRFLOW__API__AUTH_BACKEND: 'airflow.api.auth.backend.basic_auth'
+    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
+    # yamllint disable rule:line-length
+    # Use simple http server on scheduler for health checks
+    # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server
+    # yamllint enable rule:line-length
+    AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
+    # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
+    # for other purpose (development, test and especially production usage) build/extend Airflow image.
+    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
-    - ./dags:/opt/airflow/dags
-    - ./logs:/opt/airflow/logs
-    - ./plugins:/opt/airflow/plugins
+    - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
+    - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
+    - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
+    - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
   user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
   depends_on:
+    &airflow-common-depends-on
     redis:
       condition: service_healthy
     postgres:
@@ -72,64 +93,191 @@ services:
       - postgres-db-volume:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "airflow"]
-      interval: 5s
+      interval: 10s
       retries: 5
+      start_period: 5s
     restart: always
 
   redis:
     image: redis:latest
-    ports:
-      - 6379:6379
+    expose:
+      - 6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
+      interval: 10s
       timeout: 30s
       retries: 50
+      start_period: 30s
     restart: always
 
   airflow-webserver:
     <<: *airflow-common
     command: webserver
     ports:
-      - 8080:8080
+      - "8080:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
-      interval: 10s
+      interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 30s
     restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
 
   airflow-scheduler:
     <<: *airflow-common
     command: scheduler
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
 
   airflow-worker:
     <<: *airflow-common
     command: celery worker
+    healthcheck:
+      # yamllint disable rule:line-length
+      test:
+        - "CMD-SHELL"
+        - 'celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}" || celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"'
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    environment:
+      <<: *airflow-common-env
+      # Required to handle warm shutdown of the celery workers properly
+      # See https://airflow.apache.org/docs/docker-stack/entrypoint.html#signal-propagation
+      DUMB_INIT_SETSID: "0"
     restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-triggerer:
+    <<: *airflow-common
+    command: triggerer
+    healthcheck:
+      test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
 
   airflow-init:
     <<: *airflow-common
-    command: version
+    entrypoint: /bin/bash
+    # yamllint disable rule:line-length
+    command:
+      - -c
+      - |
+        if [[ -z "${AIRFLOW_UID}" ]]; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: AIRFLOW_UID not set!\e[0m"
+          echo "If you are on Linux, you SHOULD follow the instructions below to set "
+          echo "AIRFLOW_UID environment variable, otherwise files will be owned by root."
+          echo "For other operating systems you can get rid of the warning with manually created .env file:"
+          echo "    See: https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#setting-the-right-airflow-user"
+          echo
+        fi
+        one_meg=1048576
+        mem_available=$$(($$(getconf _PHYS_PAGES) * $$(getconf PAGE_SIZE) / one_meg))
+        cpus_available=$$(grep -cE 'cpu[0-9]+' /proc/stat)
+        disk_available=$$(df / | tail -1 | awk '{print $$4}')
+        warning_resources="false"
+        if (( mem_available < 4000 )) ; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough memory available for Docker.\e[0m"
+          echo "At least 4GB of memory required. You have $$(numfmt --to iec $$((mem_available * one_meg)))"
+          echo
+          warning_resources="true"
+        fi
+        if (( cpus_available < 2 )); then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough CPUS available for Docker.\e[0m"
+          echo "At least 2 CPUs recommended. You have $${cpus_available}"
+          echo
+          warning_resources="true"
+        fi
+        if (( disk_available < one_meg * 10 )); then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough Disk space available for Docker.\e[0m"
+          echo "At least 10 GBs recommended. You have $$(numfmt --to iec $$((disk_available * 1024 )))"
+          echo
+          warning_resources="true"
+        fi
+        if [[ $${warning_resources} == "true" ]]; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: You have not enough resources to run Airflow (see above)!\e[0m"
+          echo "Please follow the instructions to increase amount of resources available:"
+          echo "   https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#before-you-begin"
+          echo
+        fi
+        mkdir -p /sources/logs /sources/dags /sources/plugins
+        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
+        exec /entrypoint airflow version
+    # yamllint enable rule:line-length
     environment:
       <<: *airflow-common-env
-      _AIRFLOW_DB_UPGRADE: 'true'
+      _AIRFLOW_DB_MIGRATE: 'true'
       _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
+      _PIP_ADDITIONAL_REQUIREMENTS: ''
+    user: "0:0"
+    volumes:
+      - ${AIRFLOW_PROJ_DIR:-.}:/sources
 
+  airflow-cli:
+    <<: *airflow-common
+    profiles:
+      - debug
+    environment:
+      <<: *airflow-common-env
+      CONNECTION_CHECK_MAX_COUNT: "0"
+    # Workaround for entrypoint issue. See: https://github.com/apache/airflow/issues/16252
+    command:
+      - bash
+      - -c
+      - airflow
+
+  # You can enable flower by adding "--profile flower" option e.g. docker-compose --profile flower up
+  # or by explicitly targeted on the command line e.g. docker-compose up flower.
+  # See: https://docs.docker.com/compose/profiles/
   flower:
     <<: *airflow-common
     command: celery flower
+    profiles:
+      - flower
     ports:
-      - 5555:5555
+      - "5555:5555"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
-      interval: 10s
+      interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 30s
     restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
 
 volumes:
   postgres-db-volume:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-apache-airflow==2.0.2
-apache-airflow-providers-sqlite==1.0.2
+apache-airflow==2.8.3
 pre-commit


### PR DESCRIPTION
- Bump airflow version to 2.8.3. 
  - Use official docker compose `curl -LfO 'https://airflow.apache.org/docs/apache-airflow/2.8.3/docker-compose.yaml'` as base
- Change DummyOperator to EmptyOperator. 
- Change deprecated execution_date to dag_run.logical_date.

Test all DAGs
![image](https://github.com/gcampspo8/advanced-airflow/assets/91972345/be58c58c-81cc-45ec-b02c-adff7ab4601b)
